### PR TITLE
Migrate to three.js 0.125

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4873,9 +4873,9 @@
       }
     },
     "three": {
-      "version": "0.117.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.117.1.tgz",
-      "integrity": "sha512-t4zeJhlNzUIj9+ub0l6nICVimSuRTZJOqvk3Rmlu+YGdTOJ49Wna8p7aumpkXJakJfITiybfpYE1XN1o1Z34UQ==",
+      "version": "0.125.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.125.0.tgz",
+      "integrity": "sha512-qL36qUGsPQ/Ofo/RZdXwHwM7A8wzUSAIyawtjIebJSPvounUQeneSqxI0aBY2iwKpseGy+RUtj3C5f/z4poyXw==",
       "dev": true
     },
     "through2": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "file-loader": "^6.0.0",
     "html-webpack-plugin": "^4.3.0",
     "style-loader": "^1.2.1",
-    "three": "^0.117.1",
+    "three": "^0.125.0",
     "url-loader": "^4.1.0",
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^4.2.2"

--- a/src/GameState.ts
+++ b/src/GameState.ts
@@ -20,7 +20,7 @@ export default class GameState{
     constructor(scene: THREE.Scene, viewScale: number, overlay: THREE.Scene, settings: Settings, camera: THREE.Camera, windowHalfX: number, windowHalfY: number, sendMessage: (text: string) => void){
         this.sendMessage = sendMessage;
 
-        const AddPlanet = (semimajor_axis: number, eccentricity: number, inclination: number, ascending_node: number, argument_of_perihelion: number, color: string, GM: number, parent: CelestialBody, texture: string, radius: number, params: any, name: string, orbitGeometry: THREE.Geometry) =>
+        const AddPlanet = (semimajor_axis: number, eccentricity: number, inclination: number, ascending_node: number, argument_of_perihelion: number, color: string, GM: number, parent: CelestialBody, texture: string, radius: number, params: any, name: string, orbitGeometry: THREE.BufferGeometry) =>
             addPlanet(semimajor_axis, eccentricity, inclination, ascending_node, argument_of_perihelion, color, GM, parent, texture, radius, params, name,
                 scene, viewScale, overlay, orbitGeometry, settings.center_select, settings, camera, windowHalfX, windowHalfY);
 

--- a/src/ModulatedIcosahedronGeometry.ts
+++ b/src/ModulatedIcosahedronGeometry.ts
@@ -1,9 +1,20 @@
 import * as THREE from 'three/src/Three';
 
-/// Copied from three.js IcosahedronGeometry
+/// Copied from three.js IcosahedronGeometry and PolyhedronGeometry
+///
+/// Note that UV coordinates generation is omitted.
 export class ModulatedIcosahedronGeometry extends THREE.BufferGeometry {
+    public parameters = {
+        radius: 1,
+        detail: 3,
+    };
+
     constructor(radius = 1, detail = 3, modulator: ((a: THREE.Vector3) => void)){
         super();
+
+        // Right now we are merging IcosahedronGeometry and PolyhedronGeometry into one class hierarchy,
+        // but in theory we could separate them like three.js does. In that we would have more flexibility
+        // to support other polyhedra, but we don't need it now.
         const t = ( 1 + Math.sqrt( 5 ) ) / 2;
 
         const vertices = [
@@ -19,14 +30,12 @@ export class ModulatedIcosahedronGeometry extends THREE.BufferGeometry {
             4, 9, 5, 	2, 4, 11,	6, 2, 10,	8, 6, 7,	9, 8, 1
         ];
 
-        // super( vertices, indices, radius, detail );
+        this.type = 'ModulatedIcosahedronGeometry';
 
-        // this.type = 'IcosahedronGeometry';
-
-        // this.parameters = {
-        //     radius: radius,
-        //     detail: detail
-        // };
+        this.parameters = {
+            radius: radius,
+            detail: detail
+        };
 
         const vertexBuffer: number[] = [];
         const indexBuffer: number[] = [];
@@ -44,7 +53,6 @@ export class ModulatedIcosahedronGeometry extends THREE.BufferGeometry {
         this.setAttribute( 'position', new THREE.Float32BufferAttribute( vertexBuffer, 3 ) );
         this.setIndex( indexBuffer );
         this.setAttribute( 'normal', new THREE.Float32BufferAttribute( vertexBuffer.slice(), 3 ) );
-        // this.setAttribute( 'uv', new THREE.Float32BufferAttribute( uvBuffer, 2 ) );
 
         if ( detail === 0 ) {
 

--- a/src/ModulatedIcosahedronGeometry.ts
+++ b/src/ModulatedIcosahedronGeometry.ts
@@ -59,9 +59,9 @@ export class ModulatedIcosahedronGeometry extends THREE.BufferGeometry {
         function pushVertex( vertex: THREE.Vector3 ) {
 
             for(let i = 0; i < vertexBuffer.length / 3; i++){
-                if(vertexBuffer[i * 3] === vertex.x &&
-                    vertexBuffer[i * 3 + 1] === vertex.y &&
-                    vertexBuffer[i * 3 + 2] === vertex.z){
+                if(Math.pow(vertexBuffer[i * 3] - vertex.x, 2) +
+                    Math.pow(vertexBuffer[i * 3 + 1] - vertex.y, 2) +
+                    Math.pow(vertexBuffer[i * 3 + 2] - vertex.z, 2) < 1e-3 * 1e-3){
                         indexBuffer.push(i);
                         return;
                     }

--- a/src/ModulatedIcosahedronGeometry.ts
+++ b/src/ModulatedIcosahedronGeometry.ts
@@ -67,7 +67,7 @@ export class ModulatedIcosahedronGeometry extends THREE.BufferGeometry {
                     }
             }
             vertexBuffer.push( vertex.x, vertex.y, vertex.z );
-            indexBuffer.push( vertexBuffer.length-1 );
+            indexBuffer.push( vertexBuffer.length / 3 - 1 );
         }
 
         function getVertexByIndex( index: number, vertex: THREE.Vector3 ) {

--- a/src/ModulatedIcosahedronGeometry.ts
+++ b/src/ModulatedIcosahedronGeometry.ts
@@ -1,0 +1,183 @@
+import * as THREE from 'three/src/Three';
+
+/// Copied from three.js IcosahedronGeometry
+export class ModulatedIcosahedronGeometry extends THREE.BufferGeometry {
+    constructor(radius = 1, detail = 3){
+        super();
+        const t = ( 1 + Math.sqrt( 5 ) ) / 2;
+
+        const vertices = [
+            - 1, t, 0, 	1, t, 0, 	- 1, - t, 0, 	1, - t, 0,
+            0, - 1, t, 	0, 1, t,	0, - 1, - t, 	0, 1, - t,
+            t, 0, - 1, 	t, 0, 1, 	- t, 0, - 1, 	- t, 0, 1
+        ];
+
+        const indices = [
+            0, 11, 5, 	0, 5, 1, 	0, 1, 7, 	0, 7, 10, 	0, 10, 11,
+            1, 5, 9, 	5, 11, 4,	11, 10, 2,	10, 7, 6,	7, 1, 8,
+            3, 9, 4, 	3, 4, 2,	3, 2, 6,	3, 6, 8,	3, 8, 9,
+            4, 9, 5, 	2, 4, 11,	6, 2, 10,	8, 6, 7,	9, 8, 1
+        ];
+
+        // super( vertices, indices, radius, detail );
+
+        // this.type = 'IcosahedronGeometry';
+
+        // this.parameters = {
+        //     radius: radius,
+        //     detail: detail
+        // };
+
+        const vertexBuffer: number[] = [];
+
+        // the subdivision creates the vertex buffer data
+
+        subdivide( detail );
+
+        // all vertices should lie on a conceptual sphere with a given radius
+
+        applyRadius( radius );
+
+        // build non-indexed geometry
+
+        this.setAttribute( 'position', new THREE.Float32BufferAttribute( vertexBuffer, 3 ) );
+        this.setAttribute( 'normal', new THREE.Float32BufferAttribute( vertexBuffer.slice(), 3 ) );
+        // this.setAttribute( 'uv', new THREE.Float32BufferAttribute( uvBuffer, 2 ) );
+
+        if ( detail === 0 ) {
+
+            this.computeVertexNormals(); // flat normals
+
+        } else {
+
+            this.normalizeNormals(); // smooth normals
+
+        }
+
+        function pushVertex( vertex: THREE.Vector3 ) {
+
+            vertexBuffer.push( vertex.x, vertex.y, vertex.z );
+
+        }
+
+        function getVertexByIndex( index: number, vertex: THREE.Vector3 ) {
+
+            const stride = index * 3;
+
+            vertex.x = vertices[ stride + 0 ];
+            vertex.y = vertices[ stride + 1 ];
+            vertex.z = vertices[ stride + 2 ];
+
+        }
+
+        function subdivide( detail: number ) {
+
+            const a = new THREE.Vector3();
+            const b = new THREE.Vector3();
+            const c = new THREE.Vector3();
+
+            // iterate over all faces and apply a subdivison with the given detail value
+
+            for ( let i = 0; i < indices.length; i += 3 ) {
+
+                // get the vertices of the face
+
+                getVertexByIndex( indices[ i + 0 ], a );
+                getVertexByIndex( indices[ i + 1 ], b );
+                getVertexByIndex( indices[ i + 2 ], c );
+
+                // perform subdivision
+
+                subdivideFace( a, b, c, detail );
+
+            }
+
+        }
+
+        function subdivideFace( a: THREE.Vector3, b: THREE.Vector3, c: THREE.Vector3, detail: number ) {
+
+            const cols = detail + 1;
+
+            // we use this multidimensional array as a data structure for creating the subdivision
+
+            const v = [];
+
+            // construct all of the vertices for this subdivision
+
+            for ( let i = 0; i <= cols; i ++ ) {
+
+                v[ i ] = [];
+
+                const aj = a.clone().lerp( c, i / cols );
+                const bj = b.clone().lerp( c, i / cols );
+
+                const rows = cols - i;
+
+                for ( let j = 0; j <= rows; j ++ ) {
+
+                    if ( j === 0 && i === cols ) {
+
+                        v[ i ][ j ] = aj;
+
+                    } else {
+
+                        v[ i ][ j ] = aj.clone().lerp( bj, j / rows );
+
+                    }
+
+                }
+
+            }
+
+            // construct all of the faces
+
+            for ( let i = 0; i < cols; i ++ ) {
+
+                for ( let j = 0; j < 2 * ( cols - i ) - 1; j ++ ) {
+
+                    const k = Math.floor( j / 2 );
+
+                    if ( j % 2 === 0 ) {
+
+                        pushVertex( v[ i ][ k + 1 ] );
+                        pushVertex( v[ i + 1 ][ k ] );
+                        pushVertex( v[ i ][ k ] );
+
+                    } else {
+
+                        pushVertex( v[ i ][ k + 1 ] );
+                        pushVertex( v[ i + 1 ][ k + 1 ] );
+                        pushVertex( v[ i + 1 ][ k ] );
+
+                    }
+
+                }
+
+            }
+
+        }
+
+        function applyRadius( radius: number ) {
+
+            const vertex = new THREE.Vector3();
+
+            // iterate over the entire buffer and apply the radius to each vertex
+
+            for ( let i = 0; i < vertexBuffer.length; i += 3 ) {
+
+                vertex.x = vertexBuffer[ i + 0 ];
+                vertex.y = vertexBuffer[ i + 1 ];
+                vertex.z = vertexBuffer[ i + 2 ];
+
+                vertex.normalize().multiplyScalar( radius );
+
+                vertexBuffer[ i + 0 ] = vertex.x;
+                vertexBuffer[ i + 1 ] = vertex.y;
+                vertexBuffer[ i + 2 ] = vertex.z;
+
+            }
+
+        }
+
+    }
+}

--- a/src/ModulatedIcosahedronGeometry.ts
+++ b/src/ModulatedIcosahedronGeometry.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three/src/Three';
 
 /// Copied from three.js IcosahedronGeometry
 export class ModulatedIcosahedronGeometry extends THREE.BufferGeometry {
-    constructor(radius = 1, detail = 3){
+    constructor(radius = 1, detail = 3, modulator: ((a: THREE.Vector3) => void)){
         super();
         const t = ( 1 + Math.sqrt( 5 ) ) / 2;
 
@@ -29,6 +29,7 @@ export class ModulatedIcosahedronGeometry extends THREE.BufferGeometry {
         // };
 
         const vertexBuffer: number[] = [];
+        const indexBuffer: number[] = [];
 
         // the subdivision creates the vertex buffer data
 
@@ -41,6 +42,7 @@ export class ModulatedIcosahedronGeometry extends THREE.BufferGeometry {
         // build non-indexed geometry
 
         this.setAttribute( 'position', new THREE.Float32BufferAttribute( vertexBuffer, 3 ) );
+        this.setIndex( indexBuffer );
         this.setAttribute( 'normal', new THREE.Float32BufferAttribute( vertexBuffer.slice(), 3 ) );
         // this.setAttribute( 'uv', new THREE.Float32BufferAttribute( uvBuffer, 2 ) );
 
@@ -56,8 +58,16 @@ export class ModulatedIcosahedronGeometry extends THREE.BufferGeometry {
 
         function pushVertex( vertex: THREE.Vector3 ) {
 
+            for(let i = 0; i < vertexBuffer.length / 3; i++){
+                if(vertexBuffer[i * 3] === vertex.x &&
+                    vertexBuffer[i * 3 + 1] === vertex.y &&
+                    vertexBuffer[i * 3 + 2] === vertex.z){
+                        indexBuffer.push(i);
+                        return;
+                    }
+            }
             vertexBuffer.push( vertex.x, vertex.y, vertex.z );
-
+            indexBuffer.push( vertexBuffer.length-1 );
         }
 
         function getVertexByIndex( index: number, vertex: THREE.Vector3 ) {
@@ -170,6 +180,8 @@ export class ModulatedIcosahedronGeometry extends THREE.BufferGeometry {
                 vertex.z = vertexBuffer[ i + 2 ];
 
                 vertex.normalize().multiplyScalar( radius );
+
+                modulator(vertex);
 
                 vertexBuffer[ i + 0 ] = vertex.x;
                 vertexBuffer[ i + 1 ] = vertex.y;

--- a/src/Universe.ts
+++ b/src/Universe.ts
@@ -70,6 +70,7 @@ export default class Universe{
         // Use icosahedron instead of sphere to make it look like uniform
         // const asteroidGeometry = new THREE.IcosahedronGeometry( 1, 2 );
         const asteroidGeometry = new ModulatedIcosahedronGeometry( 1, 2, (vec) => {}/*vec.multiplyScalar(0.3 * (Math.random() - 0.5) + 1)*/ );
+        const asteroidGeometry = new ModulatedIcosahedronGeometry( 1, 2, (vec) => vec.multiplyScalar(0.3 * (Math.random() - 0.5) + 1) );
         // const asteroidVertices = asteroidGeometry.getAttribute('position') as THREE.BufferAttribute;
         // const asteroidArray = new Float32Array();
         // asteroidVertices.copyArray(asteroidArray);

--- a/src/Universe.ts
+++ b/src/Universe.ts
@@ -69,7 +69,7 @@ export default class Universe{
 
         // Use icosahedron instead of sphere to make it look like uniform
         // const asteroidGeometry = new THREE.IcosahedronGeometry( 1, 2 );
-        const asteroidGeometry = new ModulatedIcosahedronGeometry( 1, 2, (vec) => vec.multiplyScalar(0.3 * (Math.random() - 0.5) + 1) );
+        const asteroidGeometry = new ModulatedIcosahedronGeometry( 1, 2, (vec) => {}/*vec.multiplyScalar(0.3 * (Math.random() - 0.5) + 1)*/ );
         // const asteroidVertices = asteroidGeometry.getAttribute('position') as THREE.BufferAttribute;
         // const asteroidArray = new Float32Array();
         // asteroidVertices.copyArray(asteroidArray);

--- a/src/Universe.ts
+++ b/src/Universe.ts
@@ -16,7 +16,9 @@ import perlinUrl from './images/perlin.jpg';
 const GMsun = 1.327124400e11 / AU / AU/ AU; // Product of gravitational constant (G) and Sun's mass (Msun)
 const rad_per_deg = Math.PI / 180; // Radians per degrees
 
-type AddPlanetArgType = (semimajor_axis: number, eccentricity: number, inclination: number, ascending_node: number, argument_of_perihelion: number, color: string, GM: number, parent: CelestialBody, texture: string, radius: number, params: AddPlanetParams, name: string, orbitGeometry: THREE.Geometry) => CelestialBody;
+type AddPlanetArgType = (semimajor_axis: number, eccentricity: number, inclination: number, ascending_node: number,
+    argument_of_perihelion: number, color: string, GM: number, parent: CelestialBody, texture: string, radius: number,
+    params: AddPlanetParams, name: string, orbitGeometry: THREE.BufferGeometry) => CelestialBody;
 
 
 export default class Universe{
@@ -31,7 +33,7 @@ export default class Universe{
 
         const curve = new THREE.EllipseCurve(0, 0, 1, 1,
             0, Math.PI * 2, false, 90);
-        const orbitGeometry = new THREE.Geometry().setFromPoints( curve.getPoints(256) );
+        const orbitGeometry = new THREE.BufferGeometry().setFromPoints( curve.getPoints(256) );
 
         const group = new THREE.Object3D();
         const material = new THREE.MeshBasicMaterial( { color: "#ffffff" } );
@@ -66,12 +68,20 @@ export default class Universe{
 
         // Use icosahedron instead of sphere to make it look like uniform
         const asteroidGeometry = new THREE.IcosahedronGeometry( 1, 2 );
+        // const asteroidVertices = asteroidGeometry.getAttribute('position') as THREE.BufferAttribute;
+        // const asteroidArray = new Float32Array();
+        // asteroidVertices.copyArray(asteroidArray);
         // Modulate the vertices randomly to make it look like an asteroid. Simplex noise is desirable.
-        for(let i = 0; i < asteroidGeometry.vertices.length; i++){
-            asteroidGeometry.vertices[i].multiplyScalar(0.3 * (Math.random() - 0.5) + 1);
-        }
+        // for(let i = 0; i < asteroidArray.length; i += 3){
+        //     const vec = new THREE.Vector3(asteroidArray[i], asteroidArray[i+1], asteroidArray[i+2]);
+        //     vec.multiplyScalar(0.3 * (Math.random() - 0.5) + 1);
+        //     asteroidArray[i] = vec.x;
+        //     asteroidArray[i+1] = vec.y;
+        //     asteroidArray[i+2] = vec.z;
+        // }
+        // asteroidGeometry.setAttribute('position', new THREE.BufferAttribute(asteroidArray, 3));
         // Recalculate normal vectors according to updated vertices
-        asteroidGeometry.computeFaceNormals();
+        // asteroidGeometry.computeFaceNormals();
         asteroidGeometry.computeVertexNormals();
 
         // Perlin noise is applied as detail texture.

--- a/src/Universe.ts
+++ b/src/Universe.ts
@@ -3,6 +3,7 @@ import * as THREE from 'three/src/Three';
 import { CelestialBody, AU, AxisAngleQuaternion, AddPlanetParams } from './CelestialBody';
 import { Settings } from './SettingsControl';
 import { RotationButtons } from './RotationControl';
+import { ModulatedIcosahedronGeometry } from './ModulatedIcosahedronGeometry';
 
 import moonUrl from './images/moon.png';
 import mercuryUrl from './images/mercury.jpg';
@@ -67,7 +68,8 @@ export default class Universe{
         const jupiter = AddPlanet(5.204267, 0.048775, 1.305 * rad_per_deg, 100.492 * rad_per_deg, 275.066 * rad_per_deg, "#7f7f3f", 126686534 / AU / AU / AU, this.sun, jupiterUrl, 69911, {soi: 10e6}, "jupiter");
 
         // Use icosahedron instead of sphere to make it look like uniform
-        const asteroidGeometry = new THREE.IcosahedronGeometry( 1, 2 );
+        // const asteroidGeometry = new THREE.IcosahedronGeometry( 1, 2 );
+        const asteroidGeometry = new ModulatedIcosahedronGeometry( 1, 2 );
         // const asteroidVertices = asteroidGeometry.getAttribute('position') as THREE.BufferAttribute;
         // const asteroidArray = new Float32Array();
         // asteroidVertices.copyArray(asteroidArray);

--- a/src/Universe.ts
+++ b/src/Universe.ts
@@ -68,23 +68,8 @@ export default class Universe{
         const jupiter = AddPlanet(5.204267, 0.048775, 1.305 * rad_per_deg, 100.492 * rad_per_deg, 275.066 * rad_per_deg, "#7f7f3f", 126686534 / AU / AU / AU, this.sun, jupiterUrl, 69911, {soi: 10e6}, "jupiter");
 
         // Use icosahedron instead of sphere to make it look like uniform
-        // const asteroidGeometry = new THREE.IcosahedronGeometry( 1, 2 );
-        const asteroidGeometry = new ModulatedIcosahedronGeometry( 1, 2, (vec) => {}/*vec.multiplyScalar(0.3 * (Math.random() - 0.5) + 1)*/ );
+        // TODO: use simplex noise to make more smooth asteroid
         const asteroidGeometry = new ModulatedIcosahedronGeometry( 1, 2, (vec) => vec.multiplyScalar(0.3 * (Math.random() - 0.5) + 1) );
-        // const asteroidVertices = asteroidGeometry.getAttribute('position') as THREE.BufferAttribute;
-        // const asteroidArray = new Float32Array();
-        // asteroidVertices.copyArray(asteroidArray);
-        // Modulate the vertices randomly to make it look like an asteroid. Simplex noise is desirable.
-        // for(let i = 0; i < asteroidArray.length; i += 3){
-        //     const vec = new THREE.Vector3(asteroidArray[i], asteroidArray[i+1], asteroidArray[i+2]);
-        //     vec.multiplyScalar(0.3 * (Math.random() - 0.5) + 1);
-        //     asteroidArray[i] = vec.x;
-        //     asteroidArray[i+1] = vec.y;
-        //     asteroidArray[i+2] = vec.z;
-        // }
-        // asteroidGeometry.setAttribute('position', new THREE.BufferAttribute(asteroidArray, 3));
-        // Recalculate normal vectors according to updated vertices
-        // asteroidGeometry.computeFaceNormals();
         asteroidGeometry.computeVertexNormals();
 
         // Perlin noise is applied as detail texture.

--- a/src/Universe.ts
+++ b/src/Universe.ts
@@ -69,7 +69,7 @@ export default class Universe{
 
         // Use icosahedron instead of sphere to make it look like uniform
         // const asteroidGeometry = new THREE.IcosahedronGeometry( 1, 2 );
-        const asteroidGeometry = new ModulatedIcosahedronGeometry( 1, 2 );
+        const asteroidGeometry = new ModulatedIcosahedronGeometry( 1, 2, (vec) => vec.multiplyScalar(0.3 * (Math.random() - 0.5) + 1) );
         // const asteroidVertices = asteroidGeometry.getAttribute('position') as THREE.BufferAttribute;
         // const asteroidArray = new Float32Array();
         // asteroidVertices.copyArray(asteroidArray);

--- a/src/orbiter.ts
+++ b/src/orbiter.ts
@@ -97,11 +97,13 @@ function init() {
     gameState = new GameState(scene, viewScale, overlay.overlay, settings, camera, windowHalfX, windowHalfY, function(msg){ messageControl.setText(msg); });
 
     const meshMaterial = new THREE.LineBasicMaterial({color: 0x3f3f3f});
-    const meshGeometry = new THREE.Geometry();
+    const meshGeometry = new THREE.BufferGeometry();
+    const meshVertices = [];
     for(let x = -10; x <= 10; x++)
-        meshGeometry.vertices.push( new THREE.Vector3( -10, x, 0 ), new THREE.Vector3(10, x, 0));
+        meshVertices.push( -10, x, 0, 10, x, 0);
     for(let x = -10; x <= 10; x++)
-        meshGeometry.vertices.push( new THREE.Vector3( x, -10, 0 ), new THREE.Vector3(x, 10, 0));
+        meshVertices.push(   x, -10, 0, x, 10, 0);
+    meshGeometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(meshVertices), 3));
     grids = new THREE.Object3D();
     const mesh = new THREE.LineSegments(meshGeometry, meshMaterial);
     mesh.scale.x = mesh.scale.y = 100;
@@ -112,8 +114,9 @@ function init() {
 
     function addAxis(axisVector: THREE.Vector3, color: number){
         const axisXMaterial = new THREE.LineBasicMaterial({color: color});
-        const axisXGeometry = new THREE.Geometry();
-        axisXGeometry.vertices.push(new THREE.Vector3(0,0,0), axisVector);
+        const axisXGeometry = new THREE.BufferGeometry();
+        axisXGeometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(
+            [0, 0, 0, axisVector.x, axisVector.y, axisVector.z]), 3));
         const axisX = new THREE.Line(axisXGeometry, axisXMaterial);
         axisX.scale.multiplyScalar(100);
         grids.add(axisX);


### PR DESCRIPTION
Dependabot shows alert for long time, but updating three.js to the newest version was not a trivial task because many of the compatibilities were broken.

We examined incompatibilities and fixed them. In particular, the removal of Geometry class and access to vertices buffer after a BufferedGeometry was created were a big change that needed to copy the whole PolyhedronGeometry and create customized version of it.